### PR TITLE
Add dbValue for bool.

### DIFF
--- a/ndb/postgres.nim
+++ b/ndb/postgres.nim
@@ -120,6 +120,10 @@ proc dbValue*(v: string): DbValue =
   ## Wrap string value.
   DbValue(kind: dvkString, s: v)
 
+proc dbValue*(v: bool): DbValue =
+  ## Wrap bool value.
+  DbValue(kind: dvkBool, b: v)
+
 proc dbValue*(v: DateTime): DbValue =
   ## Wrap DateTime value.
   DbValue(kind: dvkTimestamptz, t: v)


### PR DESCRIPTION
@xzfc added a wrapper for bool type. I probably should've added it in the previous PR but I overlooked it. I'm rewriting Norm's PG backend with ndb so I'm fixing the things I'm currently missing.