### PR TITLE
Update Dockerfile

### DIFF
--- a/utils/Dockerfile
+++ b/utils/Dockerfile
@@ -1,3 +1,3 @@
-ARG  NIM_VERSION=1.0.0
+ARG  NIM_VERSION=1.4.0
 FROM nimlang/nim:${NIM_VERSION}
 RUN  apt-get update && apt-get install -y sqlite3 postgresql-client


### PR DESCRIPTION
The docker file requires a higher nim version, as the nim-docker-image uses ubuntu underneath.
The Ubuntu version underlying the nim 1.0 image is EoL and the repositories for it are no longer accessible.
Meaning when running building the image with the current dockerfile you will get this error:

```txt
 > [2/2] RUN  apt-get update && apt-get install -y sqlite3 postgresql-client:
#0 0.398 Ign:1 http://archive.ubuntu.com/ubuntu eoan InRelease
#0 0.433 Ign:2 http://archive.ubuntu.com/ubuntu eoan-updates InRelease
#0 0.476 Ign:3 http://archive.ubuntu.com/ubuntu eoan-backports InRelease
#0 0.509 Err:4 http://archive.ubuntu.com/ubuntu eoan Release
#0 0.509   404  Not Found [IP: 185.125.190.39 80]
#0 0.537 Ign:5 http://security.ubuntu.com/ubuntu eoan-security InRelease
#0 0.546 Err:6 http://archive.ubuntu.com/ubuntu eoan-updates Release
#0 0.546   404  Not Found [IP: 185.125.190.39 80]
#0 0.583 Err:7 http://archive.ubuntu.com/ubuntu eoan-backports Release
#0 0.583   404  Not Found [IP: 185.125.190.39 80]
#0 0.650 Err:8 http://security.ubuntu.com/ubuntu eoan-security Release
#0 0.650   404  Not Found [IP: 91.189.91.39 80]
#0 0.654 Reading package lists...
#0 1.171 E: The repository 'http://archive.ubuntu.com/ubuntu eoan Release' no longer has a Release file.
#0 1.171 E: The repository 'http://archive.ubuntu.com/ubuntu eoan-updates Release' does not have a Release file.
#0 1.171 E: The repository 'http://archive.ubuntu.com/ubuntu eoan-backports Release' does not have a Release file.
```
The same is true for the nim 1.2.0 image.
The first version where it works again is nim 1.4.0.
It may be a good idea to increment to 1.6.0 though as that'll make sure that the image lasts longer before it needs to be updated again.