### PR TITLE
Fix GC safety warning

### DIFF
--- a/ndb/postgres.nim
+++ b/ndb/postgres.nim
@@ -221,7 +221,7 @@ proc dbError*(db: DbConn) {.noreturn.} =
 
 proc tryWithStmt(db: DbConn, query: SqlQuery, args: seq[DbValue],
                  expectedStatusType: ExecStatusType,
-                 body: proc(res: PPGresult): bool {.raises: [], tags: [].}): bool =
+                 body: proc(res: PPGresult): bool {.raises: [], tags: [], gcsafe.}): bool =
   ## A common template dealing with statement initialization and finalization:
   ##
   ## 1. Initialize a statement.

--- a/ndb/sqlite.nim
+++ b/ndb/sqlite.nim
@@ -239,7 +239,7 @@ proc bindArgs(db: DbConn, stmt: var sqlite3.Pstmt, query: SqlQuery,
   return true
 
 proc tryWithStmt(db: DbConn, query: SqlQuery, args: seq[DbValue],
-                 body: proc(stmt: Pstmt): bool {.raises: [], tags: [].}): bool =
+                 body: proc(stmt: Pstmt): bool {.raises: [], tags: [], gcsafe.}): bool =
   ## A common template dealing with statement initialization and finalization:
   ##
   ## 1. Initialize a statement.


### PR DESCRIPTION
Currently `insertID` (and probably other procs) cannot be used in GC safe functions because the `body` parameter isn't considered GC safe

*Sample from my stacktrace (using latest Nim devel version)*
```
Warning: 'tryWithStmt' is not GC-safe as it performs an indirect call via 'body' [GcUnsafe2]
Warning: 'tryInsertID' is not GC-safe as it calls 'tryWithStmt' [GcUnsafe2]
Warning: 'insertID' is not GC-safe as it calls 'tryInsertID' [GcUnsafe2]
```

This just annotates the `body` proc as GC safe so that `tryWithStmt` is also considered GC safe